### PR TITLE
2.2.15-pl13

### DIFF
--- a/adm/style/acp_recenttopics.html
+++ b/adm/style/acp_recenttopics.html
@@ -186,7 +186,7 @@
 {%- endmacro %}
 
 {% macro confirmbox(name, message, default = false) -%}
-	<div id="{{ name }}_confirmbox" data-default="{{ default ? 1 : 0 }}" style="display: none;">
+	<div id="{{ name }}_confirmbox" data-default="{{ default }}" style="display: none;">
 		<h2>{{ lang('CONFIRM') }}</h2>
 		<p>{{ message }}</p>
 		<p>

--- a/adm/style/acp_recenttopics.js
+++ b/adm/style/acp_recenttopics.js
@@ -18,64 +18,65 @@ var RecentTopics = {};
 
 class LukeWCSphpBBConfirmBox {
 /*
-* phpBB ConfirmBox class for checkboxes - v1.1.0
+* phpBB ConfirmBox class for checkboxes - v1.3.0
 * @copyright (c) 2023, LukeWCS, https://www.wcsaga.org
 * @license GNU General Public License, version 2 (GPL-2.0-only)
 */
-	constructor(submitSelector) {
+	constructor(submitSelector, animDuration = 0) {
 		this.$submitObject = $(submitSelector);
+		this.$formObject = this.$submitObject.parents('form');
+		this.animDuration = animDuration;
 		var _this = this;
 
-		$('div[id$="_confirmbox"]').each(function () {
-			var elementName = $(this)[0].id.replace('_confirmbox', '')
+		this.$formObject.find('div[id$="_confirmbox"]').each(function () {
+			var elementName = this.id.replace('_confirmbox', '');
 
-			$('input[name="' + elementName + '"]')				.on('change'	, _this.Show);
-			$('input[name^="' + elementName + '_confirm_"]')	.on('click'		, _this.Button);
+			$('input[name="' + elementName + '"]')				.on('change'	, _this.#Show);
+			$('input[name^="' + elementName + '_confirm_"]')	.on('click'		, _this.#Button);
 		});
-		this.$submitObject.parents('form')						.on('reset'		, this.HideAll);
+		this.$formObject										.on('reset'		, _this.HideAll);
 	}
 
-	Show = (e) => {
-		var elementDefault = $('div[id="' + e.target.name + '_confirmbox"]').attr('data-default') == 1;
-		var $elementObject = $('input[name="' + e.target.name + '"]');
+	#Show = (e) => {
+		var $elementObject		= $('input[name="' + e.target.name + '"]');
+		var $confirmBoxObject	= $('div[id="' + e.target.name + '_confirmbox"]');
 
-		if ($elementObject.prop('checked') != elementDefault) {
-			$elementObject									.prop('disabled', true)
-			$elementObject									.addClass('confirmbox_active');
-			$('div[id="' + e.target.name + '_confirmbox"]')	.show();
-			this.$submitObject								.prop('disabled', true);
+		if ($elementObject.prop('checked') != $confirmBoxObject.attr('data-default')) {
+			this.#changeBoxState($elementObject, $confirmBoxObject, true);
 		}
 	}
 
-	Button = (e) => {
-		var elementName = e.target.name.replace(/_confirm_.*/, '');
-		var elementDefault = $('div[id="' + elementName + '_confirmbox"]').attr('data-default') == 1;
-		var $elementObject = $('input[name="' + elementName + '"]');
+	#Button = (e) => {
+		var elementName			= e.target.name.replace(/_confirm_.*/, '');
+		var $elementObject		= $('input[name="' + elementName + '"]');
+		var $confirmBoxObject	= $('div[id="' + elementName + '_confirmbox"]');
 
 		if (e.target.name.endsWith('_confirm_no')) {
-			$elementObject.prop('checked', elementDefault);
+			$elementObject.prop('checked', $confirmBoxObject.attr('data-default'));
 		}
 
-		$elementObject									.prop('disabled', false);
-		$elementObject									.removeClass('confirmbox_active');
-		$('div[id="' + elementName + '_confirmbox"]')	.hide();
-		this.$submitObject								.prop('disabled', $('input[class*="confirmbox_active"]').length);
+		this.#changeBoxState($elementObject, $confirmBoxObject, null);
 	}
 
 	HideAll = () => {
-		var $elementObject = $('input[class*="confirmbox_active"]');
+		var $elementObject		= this.$formObject.find('input.confirmbox_active');
+		var $confirmBoxObject	= this.$formObject.find('div[id$="_confirmbox"]');
 
-		$elementObject				.prop('disabled', false);
-		$elementObject				.removeClass('confirmbox_active');
-		$('div[id$="_confirmbox"]')	.hide();
-		this.$submitObject			.prop('disabled', false);
+		this.#changeBoxState($elementObject, $confirmBoxObject, false);
+	}
+
+	#changeBoxState = ($elementObject, $confirmBoxObject, showBox) => {
+		$elementObject		.prop('disabled', !!showBox);
+		$elementObject		.toggleClass('confirmbox_active', !!showBox);
+		$confirmBoxObject	[!!showBox ? 'show' : 'hide'](this.animDuration);
+		this.$submitObject	.prop('disabled', showBox ?? this.$formObject.find('input.confirmbox_active').length);
 	}
 }
 
 // Register events
 
 $(window).ready(function() {
-	RecentTopics.ConfirmBox = new LukeWCSphpBBConfirmBox('input[name="submit"]');
+	RecentTopics.ConfirmBox = new LukeWCSphpBBConfirmBox('input[name="submit"]', 300);
 });
 
 })();	// IIFE end

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "phpbb-extension",
     "description": "Recent topics Extension for phpBB 3.3. Adds a list with a number of recent topics to the board index.",
     "homepage": "https://github.com/sajaki/RecentTopics",
-    "version": "2.2.15-pl12",
+    "version": "2.2.15-pl13",
     "time": "2023-11-03",
     "license": "GPL-2.0-only",
     "authors": [

--- a/ext.php
+++ b/ext.php
@@ -29,7 +29,7 @@ class ext extends \phpbb\extension\base
 	public function is_enableable()
 	{
 		$valid_phpbb = phpbb_version_compare(PHPBB_VERSION, '3.3.5', '>=') && phpbb_version_compare(PHPBB_VERSION, '3.4.0', '<');
-		$valid_php = phpbb_version_compare(PHP_VERSION, '7.1.3', '>=') && phpbb_version_compare(PHP_VERSION, '8.3.0', '<');
+		$valid_php = phpbb_version_compare(PHP_VERSION, '7.1.3', '>=') && phpbb_version_compare(PHP_VERSION, '8.4.0', '<');
 
 		return ($valid_phpbb && $valid_php);
 	}


### PR DESCRIPTION
* LukeWCSphpBBConfirmBox 1.3.0:
  * Combined redundant code into one method.
  * Methods that are only used within the class (for events) are now defined as private.
  * Optionally, opening/closing the ConfirmBox windows can now be executed as an animation. The class supports a second parameter with which the animation can be activated and the speed can be controlled: 400 = standard, 0 = off. [Suggestion from IMC (phpBB.de)]
  * Code optimization.
* LukeWCSphpBBConfirmBox 1.2.0:
  * When the class was assigned to more than one form per template, several problems arose because the class was not previously designed for multiple instances:
    * Fix: If a ConfirmBox was opened in one of the forms, the submit button was deactivated for all forms.
    * Fix: If a ConfirmBox was opened in several forms, then when one of the ConfirmBox windows was closed, the submit buttons of all forms remained deactivated until all ConfirmBox windows in all forms were closed.
    * Fix: If a ConfirmBox was opened in several forms and then a reset was triggered in one form, the ConfirmBox windows in the other forms were also closed. The submit button on the other forms remained deactivated and inevitably the changed switches were not reset.