### PR TITLE
2.2.15-pl14

### DIFF
--- a/adm/style/acp_recenttopics.html
+++ b/adm/style/acp_recenttopics.html
@@ -10,6 +10,9 @@
  * Based on the original NV Recent Topics by Joas Schilling (nickvergessen)
  #}
 
+{% import '@paybas_recenttopics/recenttopics_macros.html' as common %}
+{% set switch_type = TOGGLECTRL_TYPE ?? 'toggle' %}
+
 {% include 'overall_header.html' %}
 
 <h1>{{ lang('RECENT_TOPICS') }}</h1>
@@ -22,46 +25,51 @@
 
 		<dl>
 			<dt>
-				<label>{{ lang('INDEX') ~ lang('COLON') }}</label><br><span>{{ lang('RT_DISPLAY_INDEX') }}</span>
+				<label>{{ lang('INDEX') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_DISPLAY_INDEX') }}</span>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_enable', RT_INDEX) }}
+				{{ common.switch('rt_enable', RT_INDEX, switch_type) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_PAGE_NUMBERMAX') ~ lang('COLON') }}</label><br><span>{{ lang('RT_PAGE_NUMBERMAX_EXP') }}</span>
+				<label>{{ lang('RT_PAGE_NUMBERMAX') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_PAGE_NUMBERMAX_EXP') }}</span>
 			</dt>
 			<dd>
-				<input type="number" name="rt_page_numbermax" size="3" min="1" max="999" value="{{ RT_PAGE_NUMBERMAX }}">
+				{{ common.number('rt_page_numbermax', RT_PAGE_NUMBERMAX, 1, 999) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_PAGE_NUMBER') ~ lang('COLON') }}</label><br><span>{{ lang('RT_PAGE_NUMBER_EXP') }}</span>
+				<label>{{ lang('RT_PAGE_NUMBER') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_PAGE_NUMBER_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_page_number', RT_PAGE_NUMBER) }}
+				{{ common.switch('rt_page_number', RT_PAGE_NUMBER, switch_type) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_MIN_TOPIC_LEVEL') ~ lang('COLON') }}</label><br><span>{{ lang('RT_MIN_TOPIC_LEVEL_EXP') }}</span>
+				<label>{{ lang('RT_MIN_TOPIC_LEVEL') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_MIN_TOPIC_LEVEL_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.select('rt_min_topic_level', loops.topiclevel_row) }}
+				{{ common.select('rt_min_topic_level', RT_MIN_TOPIC_LEVEL, RT_MIN_TOPIC_LEVEL_OPTIONS) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_ANTI_TOPICS') ~ lang('COLON') }}</label><br><span>{{ lang('RT_ANTI_TOPICS_EXP') }}</span>
+				<label>{{ lang('RT_ANTI_TOPICS') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_ANTI_TOPICS_EXP') }}</span>
 			</dt>
 			<dd>
-				<input type="text" name="rt_anti_topics" size="30" value="{{ RT_ANTI_TOPICS }}">
+				{{ common.text('rt_anti_topics', RT_ANTI_TOPICS, 30) }}
 			</dd>
 		</dl>
 
@@ -70,7 +78,7 @@
 				<label>{{ lang('RT_PARENTS') ~ lang('COLON') }}</label><br><span>{{ lang('RT_PARENTS_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_parents', RT_PARENTS) }}
+				{{ common.switch('rt_parents', RT_PARENTS, switch_type) }}
 			</dd>
 		</dl>
 	</fieldset>
@@ -80,37 +88,41 @@
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_LOCATION') ~ lang('COLON') }}</label><br><span>{{ lang('RT_LOCATION_EXP') }}</span>
+				<label>{{ lang('RT_LOCATION') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_LOCATION_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.select('rt_location', loops.location_row) }}
+				{{ common.select('rt_location', RT_LOCATION, RT_LOCATION_OPTIONS) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_NUMBER') ~ lang('COLON') }}</label><br><span>{{ lang('RT_NUMBER_EXP') }}</span>
+				<label>{{ lang('RT_NUMBER') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_NUMBER_EXP') }}</span>
 			</dt>
 			<dd>
-				<input type="number" name="rt_number" size="3" min="0" max="999" value="{{ RT_NUMBER }}">
+				{{ common.number('rt_number', RT_NUMBER, 0, 999) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_SORT_START_TIME') ~ lang('COLON') }}</label><br><span>{{ lang('RT_SORT_START_TIME_EXP') }}</span>
+				<label>{{ lang('RT_SORT_START_TIME') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_SORT_START_TIME_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_sort_start_time', RT_SORT_START_TIME) }}
+				{{ common.switch('rt_sort_start_time', RT_SORT_START_TIME, switch_type) }}
 			</dd>
 		</dl>
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_UNREAD_ONLY') ~ lang('COLON') }}</label><br><span>{{ lang('RT_UNREAD_ONLY_EXP') }}</span>
+				<label>{{ lang('RT_UNREAD_ONLY') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_UNREAD_ONLY_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_unread_only', RT_UNREAD_ONLY) }}
+				{{ common.switch('rt_unread_only', RT_UNREAD_ONLY, switch_type) }}
 			</dd>
 		</dl>
 
@@ -118,10 +130,11 @@
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_RESET_DEFAULT') ~ lang('COLON') }}</label><br><span>{{ lang('RT_RESET_DEFAULT_EXP') }}</span>
+				<label>{{ lang('RT_RESET_DEFAULT') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_RESET_DEFAULT_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_reset_default') }}
+				{{ common.switch('rt_reset_default', false, switch_type) }}
 				{{ _self.confirmbox('rt_reset_default', lang('RT_RESET_ASK_BEFORE_EXP')) }}
 			</dd>
 		</dl>
@@ -129,18 +142,18 @@
 
 
 	{% if S_RT_NEWSPAGE %}
-	<fieldset>
-		<legend>{{ lang('RT_VIEW_ON') }}</legend>
+		<fieldset>
+			<legend>{{ lang('RT_VIEW_ON') }}</legend>
 
-		<dl>
-			<dt>
-				<label>{{ lang('RT_NICKVERGESSEN_NEWSPAGE') ~ lang('COLON') }}</label>
-			</dt>
-			<dd>
-				{{ _self.switch('rt_on_newspage', RT_ON_NEWSPAGE) }}
-			</dd>
-		</dl>
-	</fieldset>
+			<dl>
+				<dt>
+					<label>{{ lang('RT_NICKVERGESSEN_NEWSPAGE') ~ lang('COLON') }}</label>
+				</dt>
+				<dd>
+					{{ common.switch('rt_on_newspage', RT_ON_NEWSPAGE, switch_type) }}
+				</dd>
+			</dl>
+		</fieldset>
 	{% endif %}
 
 	<fieldset>
@@ -157,7 +170,8 @@
 
 		<dl>
 			<dt>
-				<label>{{ lang('RT_DONATE_SHORT') ~ lang('COLON') }}</label><br><span>{{ lang('RT_DONATE_EXPLAIN') }}</span>
+				<label>{{ lang('RT_DONATE_SHORT') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_DONATE_EXPLAIN') }}</span>
 			</dt>
 			<dd>
 				<a href="{{ lang('RT_DONATE_URL') }}" target="_blank"><img src="{{ lang('RT_PAYPAL_IMAGE_URL') }}" border="0" alt="{{ lang('RT_PAYPAL_ALT') }}" style="cursor:pointer"></a>
@@ -172,18 +186,6 @@
 
 {% INCLUDECSS '@paybas_recenttopics/acp_recenttopics.css' %}
 {% INCLUDEJS '@paybas_recenttopics/acp_recenttopics.js' %}
-
-{% macro switch(name, checked = false) -%}
-	<input type="checkbox" class="toggle" name="{{ name }}" value="1"{{ checked ? ' checked' }}>
-{%- endmacro %}
-
-{% macro select(name, array) -%}
-	<select class="input" name="{{ name }}">
-		{% for array_row in array %}
-			<option value="{{ array_row.VALUE }}"{{ array_row.SELECTED }}>{{ array_row.OPTION }}</option>
-		{% endfor %}
-	</select>
-{%- endmacro %}
 
 {% macro confirmbox(name, message, default = false) -%}
 	<div id="{{ name }}_confirmbox" data-default="{{ default }}" style="display: none;">

--- a/adm/style/acp_recenttopics.js
+++ b/adm/style/acp_recenttopics.js
@@ -18,14 +18,14 @@ var RecentTopics = {};
 
 class LukeWCSphpBBConfirmBox {
 /*
-* phpBB ConfirmBox class for checkboxes - v1.3.0
+* phpBB ConfirmBox class for checkboxes and yes/no radio buttons - v1.4.0
 * @copyright (c) 2023, LukeWCS, https://www.wcsaga.org
 * @license GNU General Public License, version 2 (GPL-2.0-only)
 */
 	constructor(submitSelector, animDuration = 0) {
-		this.$submitObject = $(submitSelector);
-		this.$formObject = this.$submitObject.parents('form');
-		this.animDuration = animDuration;
+		this.$submitObject	= $(submitSelector);
+		this.$formObject	= this.$submitObject.parents('form');
+		this.animDuration	= animDuration;
 		var _this = this;
 
 		this.$formObject.find('div[id$="_confirmbox"]').each(function () {
@@ -52,7 +52,11 @@ class LukeWCSphpBBConfirmBox {
 		var $confirmBoxObject	= $('div[id="' + elementName + '_confirmbox"]');
 
 		if (e.target.name.endsWith('_confirm_no')) {
-			$elementObject.prop('checked', $confirmBoxObject.attr('data-default'));
+			if ($elementObject.get(0).type == 'checkbox') {
+				$elementObject.prop('checked', $confirmBoxObject.attr('data-default'));
+			} else if ($elementObject.get(0).type == 'radio') {
+				$elementObject.filter('[value="' + ($confirmBoxObject.attr('data-default') ? '1' : '0') + '"]').prop('checked', true);
+			}
 		}
 
 		this.#changeBoxState($elementObject, $confirmBoxObject, null);
@@ -68,7 +72,7 @@ class LukeWCSphpBBConfirmBox {
 	#changeBoxState = ($elementObject, $confirmBoxObject, showBox) => {
 		$elementObject		.prop('disabled', !!showBox);
 		$elementObject		.toggleClass('confirmbox_active', !!showBox);
-		$confirmBoxObject	[!!showBox ? 'show' : 'hide'](this.animDuration);
+		$confirmBoxObject	[showBox ? 'show' : 'hide'](this.animDuration);
 		this.$submitObject	.prop('disabled', showBox ?? this.$formObject.find('input.confirmbox_active').length);
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "phpbb-extension",
     "description": "Recent topics Extension for phpBB 3.3. Adds a list with a number of recent topics to the board index.",
     "homepage": "https://github.com/sajaki/RecentTopics",
-    "version": "2.2.15-pl13",
-    "time": "2023-11-03",
+    "version": "2.2.15-pl14",
+    "time": "2023-12-03",
     "license": "GPL-2.0-only",
     "authors": [
 		{
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3,<8.3.0@dev",
+        "php": ">=7.1.3,<8.4.0@dev",
         "composer/installers": "~1.0"
     },
     "extra": {

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -97,52 +97,33 @@ class admin_controller
 			trigger_error($this->language->lang('CONFIG_UPDATED') . adm_back_link($this->u_action));
 		}
 
-		$topic_types = [
-			0 => $this->language->lang('POST') ,
-			1 => $this->language->lang('POST_STICKY'),
-			2 => $this->language->lang('ANNOUNCEMENTS'),
-			3 => $this->language->lang('GLOBAL_ANNOUNCEMENT'),
-		];
-
-		foreach ($topic_types as $key => $topic_type)
-		{
-			$this->template->assign_block_vars('topiclevel_row', [
-				'VALUE'		=> $key,
-				'SELECTED'	=> ($this->config['rt_min_topic_level'] == $key) ? ' selected' : '',
-				'OPTION'	=> $topic_type,
-			]);
-		}
-
-		$display_types = [
-			'RT_TOP'	 => $this->language->lang('RT_TOP'),
-			'RT_BOTTOM'	 => $this->language->lang('RT_BOTTOM'),
-			'RT_SIDE'	 => $this->language->lang('RT_SIDE'),
-			'RT_SEPARAT' => $this->language->lang('RT_SEPARAT'),
-		];
-
-		foreach ($display_types as $key => $display_type)
-		{
-			$this->template->assign_block_vars('location_row', [
-				'VALUE'    => $key,
-				'SELECTED' => ($this->config['rt_location'] == $key) ? ' selected' : '',
-				'OPTION'   => $display_type,
-			]);
-		}
-
 		$this->template->assign_vars([
-			'U_ACTION'				=> $this->u_action,
-			'RT_INDEX'				=> (int) $this->config['rt_index'],
-			'RT_PAGE_NUMBER'		=> (int) $this->config['rt_page_number'],
-			'RT_PAGE_NUMBERMAX'		=> (int) $this->config['rt_page_numbermax'],
-			'RT_ANTI_TOPICS'		=> $this->config['rt_anti_topics'],
-			'RT_PARENTS'			=> (int) $this->config['rt_parents'],
-			'RT_NUMBER'				=> (int) $this->config['rt_number'],
-			'RT_SORT_START_TIME'	=> (int) $this->config['rt_sort_start_time'],
-			'RT_UNREAD_ONLY'		=> (int) $this->config['rt_unread_only'],
-			'RT_ON_NEWSPAGE'		=> $this->config['rt_on_newspage'],
-			'S_RT_NEWSPAGE'			=> $this->ext_manager->is_enabled('nickvergessen/newspage'),
+			'U_ACTION'						=> $this->u_action,
+			'RT_INDEX'						=> (int) $this->config['rt_index'],
+			'RT_PAGE_NUMBER'				=> (int) $this->config['rt_page_number'],
+			'RT_PAGE_NUMBERMAX'				=> (int) $this->config['rt_page_numbermax'],
+			'RT_ANTI_TOPICS'				=> $this->config['rt_anti_topics'],
+			'RT_PARENTS'					=> (int) $this->config['rt_parents'],
+			'RT_NUMBER'						=> (int) $this->config['rt_number'],
+			'RT_SORT_START_TIME'			=> (int) $this->config['rt_sort_start_time'],
+			'RT_UNREAD_ONLY'				=> (int) $this->config['rt_unread_only'],
+			'RT_ON_NEWSPAGE'				=> $this->config['rt_on_newspage'],
+			'S_RT_NEWSPAGE'					=> $this->ext_manager->is_enabled('nickvergessen/newspage'),
+			'RT_MIN_TOPIC_LEVEL'			=> (int) $this->config['rt_min_topic_level'],
+			'RT_MIN_TOPIC_LEVEL_OPTIONS' => [
+				'POST'						=> '0',
+				'POST_STICKY'				=> '1',
+				'ANNOUNCEMENTS'				=> '2',
+				'GLOBAL_ANNOUNCEMENT'		=> '3',
+			],
+			'RT_LOCATION'					=> $this->config['rt_location'],
+			'RT_LOCATION_OPTIONS' => [
+				'RT_TOP'	 				=> 'RT_TOP',
+				'RT_BOTTOM'	 				=> 'RT_BOTTOM',
+				'RT_SIDE'	 				=> 'RT_SIDE',
+				'RT_SEPARAT' 				=> 'RT_SEPARAT',
+			],
 		]);
-
 	}
 
 	/**

--- a/event/ucp_listener.php
+++ b/event/ucp_listener.php
@@ -144,24 +144,15 @@ class ucp_listener implements EventSubscriberInterface
 					'A_RT_LOCATION' => true,
 				];
 
-				$display_types = [
-					'RT_TOP'	 => $this->language->lang('RT_TOP'),
-					'RT_BOTTOM'	 => $this->language->lang('RT_BOTTOM'),
-					'RT_SIDE'	 => $this->language->lang('RT_SIDE'),
-					'RT_SEPARAT' => $this->language->lang('RT_SEPARAT'),
+				$template_vars += [
+					'RT_LOCATION'				=> $event['data']['rt_location'],
+					'RT_LOCATION_OPTIONS' => [
+						'RT_TOP'				=> 'RT_TOP',
+						'RT_BOTTOM'				=> 'RT_BOTTOM',
+						'RT_SIDE'				=> 'RT_SIDE',
+						'RT_SEPARAT'			=> 'RT_SEPARAT',
+					],
 				];
-
-				foreach ($display_types as $key => $display_type)
-				{
-					$this->template->assign_block_vars(
-						'location_row',
-						[
-							'VALUE'	   => $key,
-							'SELECTED' => ($event['data']['rt_location'] == $key) ? ' selected' : '',
-							'OPTION'   => $display_type,
-						]
-					);
-				}
 			}
 
 			if ($this->auth->acl_get('u_rt_number'))
@@ -175,16 +166,16 @@ class ucp_listener implements EventSubscriberInterface
 			if ($this->auth->acl_get('u_rt_sort_start_time'))
 			{
 				$template_vars += [
-				'A_RT_SORT_START_TIME' => true,
-				'S_RT_SORT_START_TIME' => $event['data']['rt_sort_start_time'],
+					'A_RT_SORT_START_TIME' => true,
+					'S_RT_SORT_START_TIME' => $event['data']['rt_sort_start_time'],
 				];
 			}
 
 			if ($this->auth->acl_get('u_rt_unread_only'))
 			{
 				$template_vars += [
-				'A_RT_UNREAD_ONLY' => true,
-				'S_RT_UNREAD_ONLY' => $event['data']['rt_unread_only'],
+					'A_RT_UNREAD_ONLY' => true,
+					'S_RT_UNREAD_ONLY' => $event['data']['rt_unread_only'],
 				];
 			}
 

--- a/styles/all/template/event/ucp_prefs_view_select_menu_append.html
+++ b/styles/all/template/event/ucp_prefs_view_select_menu_append.html
@@ -10,6 +10,8 @@
  * Based on the original NV Recent Topics by Joas Schilling (nickvergessen)
  #}
 
+{% import '@paybas_recenttopics/recenttopics_macros.html' as common %}
+
 {% if S_RT_SHOW %}
 	<hr>
 	{% if A_RT_ENABLE %}
@@ -18,27 +20,29 @@
 				<label>{{ lang('RT_ENABLE') ~ lang('COLON') }}</label>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_enable', S_RT_ENABLE) }}
+				{{ common.switch('rt_enable', S_RT_ENABLE, 'radio') }}
 			</dd>
 		</dl>
 	{% endif %}
 	{% if A_RT_LOCATION %}
 		<dl>
 			<dt>
-				<label>{{ lang('RT_LOCATION') ~ lang('COLON') }}</label><br><span>{{ lang('RT_LOCATION_EXP') }}</span>
+				<label>{{ lang('RT_LOCATION') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_LOCATION_EXP') }}</span>
 			</dt>
 			<dd>
-				{{ _self.select('rt_location', loops.location_row) }}
+				{{ common.select('rt_location', RT_LOCATION, RT_LOCATION_OPTIONS) }}
 			</dd>
 		</dl>
 	{% endif %}
 	{% if A_RT_NUMBER %}
 		<dl>
 			<dt>
-				<label>{{ lang('RT_NUMBER') ~ lang('COLON') }}</label><br><span>{{ lang('RT_NUMBER_EXP') }}</span>
+				<label>{{ lang('RT_NUMBER') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_NUMBER_EXP') }}</span>
 			</dt>
 			<dd>
-				<input type="number" name="rt_number" size="3" min="0" max="999" value="{{ RT_NUMBER }}">
+				{{ common.number('rt_number', RT_NUMBER, 0, 999) }}
 			</dd>
 		</dl>
 	{% endif %}
@@ -46,10 +50,11 @@
 	{% if A_RT_SORT_START_TIME %}
 		<dl>
 			<dt>
-				<label>{{ lang('RT_SORT_START_TIME') ~ lang('COLON') }}</label><br><span>{{ lang('RT_SORT_START_TIME_EXP') }}
+				<label>{{ lang('RT_SORT_START_TIME') ~ lang('COLON') }}</label><br>
+				<span>{{ lang('RT_SORT_START_TIME_EXP') }}
 			</dt>
 			<dd>
-				{{ _self.switch('rt_sort_start_time', S_RT_SORT_START_TIME) }}
+				{{ common.switch('rt_sort_start_time', S_RT_SORT_START_TIME, 'radio') }}
 			</dd>
 		</dl>
 	{% endif %}
@@ -59,21 +64,8 @@
 				<label>{{ lang('RT_UNREAD_ONLY') ~ lang('COLON') }}</label>
 			</dt>
 			<dd>
-				{{ _self.switch('rt_unread_only', S_RT_UNREAD_ONLY) }}
+				{{ common.switch('rt_unread_only', S_RT_UNREAD_ONLY, 'radio') }}
 			</dd>
 		</dl>
 	{% endif %}
 {% endif %}
-
-{% macro switch(name, checked = false) %}
-	<label><input type="radio" name="{{ name }}" value="1"{{ checked ? ' checked' }}> {{ lang('YES') }}</label>
-	<label><input type="radio" name="{{ name }}" value="0"{{ !checked ? ' checked' }}> {{ lang('NO') }}</label>
-{% endmacro %}
-
-{% macro select(name, array) %}
-	<select class="input" name="{{ name }}">
-		{% for array_row in array %}
-			<option value="{{ array_row.VALUE }}"{{ array_row.SELECTED }}>{{ array_row.OPTION }}</option>
-		{% endfor %}
-	</select>
-{% endmacro %}

--- a/styles/all/template/recenttopics_macros.html
+++ b/styles/all/template/recenttopics_macros.html
@@ -1,0 +1,36 @@
+{#
+ *
+ * Recent Topics. An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2022, IMC, https://github.com/IMC-GER / LukeWCS, https://github.com/LukeWCS
+ * @copyright (c) 2017, Sajaki, https://www.avathar.be
+ * @copyright (c) 2015, PayBas
+ * @license GNU General Public License, version 2 (GPL-2.0-only)
+ *
+ * Based on the original NV Recent Topics by Joas Schilling (nickvergessen)
+ #}
+
+{% macro switch(name, checked = false, type = 'toggle') -%}
+	{% if type == 'toggle' || type == 'checkbox' -%}
+		<input type="checkbox"{{ type == 'toggle' ? ' class="toggle"' }} name="{{ name }}" value="1"{{ checked ? ' checked' }}>
+	{%- elseif type == 'radio' -%}
+		<label><input type="radio" class="radio" name="{{ name }}" value="1"{{ checked ? ' checked' }}> {{ lang('YES') }}</label>
+		<label><input type="radio" class="radio" name="{{ name }}" value="0"{{ !checked ? ' checked' }}> {{ lang('NO') }}</label>
+	{%- endif %}
+{%- endmacro %}
+
+{% macro select(name, value, options) -%}
+	<select name="{{ name }}">
+		{% for opt_lang_var, opt_value in options %}
+			<option value="{{ opt_value }}"{{ opt_value == value ? ' selected' }}>{{ lang(opt_lang_var) }}</option>
+		{% endfor %}
+	</select>
+{%- endmacro %}
+
+{% macro number(name, value, min, max, step = 1, placeholder = '') -%}
+	<input type="number" name="{{ name }}" value="{{ value }}" min="{{ min }}" max="{{ max }}" step="{{ step }}"{{ placeholder ? ' placeholder="' ~ placeholder ~ '"' }}>
+{%- endmacro %}
+
+{% macro text(name, value, size = 10, placeholder = '', pattern = '') -%}
+	<input type="text" name="{{ name }}" value="{{ value }}" size="{{ size }}"{{ placeholder ? ' placeholder="' ~ placeholder ~ '"' }}{{ pattern ? ' pattern="' ~ pattern ~ '"' }}>
+{%- endmacro %}


### PR DESCRIPTION
* PHP:
  * ACP and UCP Controller: Generation of `select` elements reduced to the necessary minimum and HTML moved into the template.
* Template:
  * 2 new Twig macros: `number()` and `text()` for entering numbers and text.
  * The `switch()` macro has been extended to also generate checkboxes and radio buttons. Necessary for TC compatibility.
  * All macros combined in a single file, which are included together by the ACP and UCP template. So no more redundancy in the macros. *JS:
  * LukeWCSphpBBConfirmBox 1.4.0:
    * The class can now also handle radio buttons. Manual adjustment is not necessary; it is automatically recognized which type (checkbox or radio) was used for a switch. Necessary for TC compatibility.