### PR TITLE
2.2.15-pl15

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Pull Request rules for this phpBB Extension repository:
+
+* No PR will be accepted that would add a new language pack. (Corrections for the included language packs are welcome.)
+* No PR will be accepted that would add a new style template. (Corrections for prosilver are welcome.)
+* No PR will be accepted if the description is missing. This applies in particular to code changes.
+
+This message does not automatically destroy itself after reading and must be removed manually. ^^

--- a/README.md
+++ b/README.md
@@ -1,70 +1,13 @@
-Recent Topics for phpBB 3.2 / 3.3
-==========
+## Recent Topics NG
+Extension for phpBB - Adds a list with a number of recent topics to the board index.
 
-Extension for phpBB to display recent topics.
 Based on NV Recent Topics for phpBB 3.0, by Joas Schilling ([nickvergessen](https://github.com/nickvergessen))
 
-#### Version
-v2.2.15 (05/04/2021) 
-[![stable](http://badges.github.io/stability-badges/dist/stable.svg)](http://github.com/badges/stability-badges)
-    
-#### Support
-- [Support forum](https://www.avathar.be/forum/viewforum.php?f=65)
-
 #### Requirements
-- phpBB 3.2.0 or higher
+* phpBB 3.3.5 - 3.3.x
+* PHP 7.1.3 - 8.3.x
 
-#### Features
-- Adds a list of recent (or unread) topics or last reply to topics to the index page.
-- UCP permissions and settings so users can choose their own preferences to override ACP.
-- can view all recent topics on a special page /app.php/rt (as of 2.2.7)
-- ACP / UCP Options:
-  - Screen location : Top, bottom or Right.
-  - number of topics to show per page  (as of 2.2.7)
-  - sort by topic start time, instead of last post time
-  - only show unread topics
-- ACP Options  
-  - Show all recent topic pages
-  - max. number of pages
-  - set minimum topic type level to display (normal/sticky/announcement/global)
-  - exclusion of topics (by ID)
-  - display parent forum name in the row
-- Inherits all styling from regular "viewforum" templates
-- filters "re: from replies" (as of 2.2.11)
-- compatible with 
-   - "Pre:fixed" Extension from imkingdavid 
-   - “Topic Prefix“ Extension from Stathis.
-   - official extension "phpbb/topicprefixes"
-   - Mchat 2.0.1 (as of 2.2.3)  
-   - Collapsible Categories v2 (as of v2.2.9)
-- Tested on:
-  - prosilver  
-  - we_clearblue (only non-cdb verion), 
-  - proflat 
-  - pbWow3
-  - ComBoot (as of 2.2.7, only non-cdb verion)
-
-![Screenshot](screenshot.png)
-
-#### Languages supported
-- English, German, French, Dutch, Spanish, Czech, Russian, Portuguese, Arabic, Czech
-  
-### Installation
-1. [Download the latest release](https://www.avathar.be/forum/app.php/dlext/details?df_id=35) and unzip it.
-    - cdb build = built for phpBB CDB
-    - standard build = has extra features, support for styles not in Cdb.
-2. Copy the entire contents from the unzipped folder to `/ext/paybas/recenttopics/`.
-3. Navigate in the ACP to `Customise -> Manage extensions`.
-4. Find `Recent Topics` under "Disabled Extensions" and click `Enable`.
-
-#### Uninstallation
-1. Navigate in the ACP to `Customise -> Manage extensions`.
-2. Click the `Disable` link for `Recent Topics`.
-3. To permanently uninstall, click `Delete Data`, then delete the `recenttopics` folder from `/ext/paybas/`.
-
-### License
-[GNU General Public License v2](http://opensource.org/licenses/GPL-2.0)
-
-© 2015 - PayBas
-© 2017 - Sajaki
-
+#### Authors
+* © 2022 - IMC-GER & LukeWCS
+* © 2017 - Sajaki
+* © 2015 - PayBas

--- a/adm/style/acp_recenttopics.js
+++ b/adm/style/acp_recenttopics.js
@@ -12,24 +12,24 @@
 
 var RecentTopics = {};
 
-(function () {	// IIFE start
+(function ($) {	// IIFE start
 
 'use strict';
 
 class LukeWCSphpBBConfirmBox {
 /*
-* phpBB ConfirmBox class for checkboxes and yes/no radio buttons - v1.4.0
+* phpBB ConfirmBox class for checkboxes and yes/no radio buttons - v1.4.3
 * @copyright (c) 2023, LukeWCS, https://www.wcsaga.org
 * @license GNU General Public License, version 2 (GPL-2.0-only)
 */
 	constructor(submitSelector, animDuration = 0) {
+		let _this = this;
 		this.$submitObject	= $(submitSelector);
 		this.$formObject	= this.$submitObject.parents('form');
 		this.animDuration	= animDuration;
-		var _this = this;
 
 		this.$formObject.find('div[id$="_confirmbox"]').each(function () {
-			var elementName = this.id.replace('_confirmbox', '');
+			const elementName = this.id.replace('_confirmbox', '');
 
 			$('input[name="' + elementName + '"]')				.on('change'	, _this.#Show);
 			$('input[name^="' + elementName + '_confirm_"]')	.on('click'		, _this.#Button);
@@ -38,8 +38,8 @@ class LukeWCSphpBBConfirmBox {
 	}
 
 	#Show = (e) => {
-		var $elementObject		= $('input[name="' + e.target.name + '"]');
-		var $confirmBoxObject	= $('div[id="' + e.target.name + '_confirmbox"]');
+		const $elementObject	= $('input[name="' + e.target.name + '"]');
+		const $confirmBoxObject	= $('div[id="' + e.target.name + '_confirmbox"]');
 
 		if ($elementObject.prop('checked') != $confirmBoxObject.attr('data-default')) {
 			this.#changeBoxState($elementObject, $confirmBoxObject, true);
@@ -47,24 +47,24 @@ class LukeWCSphpBBConfirmBox {
 	}
 
 	#Button = (e) => {
-		var elementName			= e.target.name.replace(/_confirm_.*/, '');
-		var $elementObject		= $('input[name="' + elementName + '"]');
-		var $confirmBoxObject	= $('div[id="' + elementName + '_confirmbox"]');
+		const elementName		= e.target.name.replace(/_confirm_.*/, '');
+		const $elementObject	= $('input[name="' + elementName + '"]');
+		const $confirmBoxObject	= $('div[id="' + elementName + '_confirmbox"]');
+		const elementType		= $elementObject.attr('type');
 
 		if (e.target.name.endsWith('_confirm_no')) {
-			if ($elementObject.get(0).type == 'checkbox') {
+			if (elementType == 'checkbox') {
 				$elementObject.prop('checked', $confirmBoxObject.attr('data-default'));
-			} else if ($elementObject.get(0).type == 'radio') {
+			} else if (elementType == 'radio') {
 				$elementObject.filter('[value="' + ($confirmBoxObject.attr('data-default') ? '1' : '0') + '"]').prop('checked', true);
 			}
 		}
-
 		this.#changeBoxState($elementObject, $confirmBoxObject, null);
 	}
 
 	HideAll = () => {
-		var $elementObject		= this.$formObject.find('input.confirmbox_active');
-		var $confirmBoxObject	= this.$formObject.find('div[id$="_confirmbox"]');
+		const $elementObject	= this.$formObject.find('input.confirmbox_active');
+		const $confirmBoxObject	= this.$formObject.find('div[id$="_confirmbox"]');
 
 		this.#changeBoxState($elementObject, $confirmBoxObject, false);
 	}
@@ -83,4 +83,4 @@ $(window).ready(function() {
 	RecentTopics.ConfirmBox = new LukeWCSphpBBConfirmBox('input[name="submit"]', 300);
 });
 
-})();	// IIFE end
+})(jQuery);	// IIFE end

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,26 @@
 {
     "name": "paybas/recenttopics",
     "type": "phpbb-extension",
-    "description": "Recent topics Extension for phpBB 3.3. Adds a list with a number of recent topics to the board index.",
+    "description": "Adds a list with a number of recent topics to the board index.",
     "homepage": "https://github.com/sajaki/RecentTopics",
-    "version": "2.2.15-pl14",
-    "time": "2023-12-03",
+    "version": "2.2.15-pl15",
+    "time": "2024-02-23",
     "license": "GPL-2.0-only",
     "authors": [
 		{
 			"name": "Thorsten Ahlers",
 			"homepage": "https://github.com/IMC-GER",
-			"role": "Fork developer"
+			"role": "Developer"
 		},
 		{
 			"name": "LukeWCS",
 			"homepage": "https://github.com/LukeWCS",
-			"role": "Fork developer"
+			"role": "Developer"
 		},
         {
             "name": "Andreas Vandenberghe",
             "homepage": "https://www.avathar.be",
-            "role": "Developer"
+            "role": "Previous Developer"
         },
         {
             "name": "PayBas",
@@ -36,15 +36,9 @@
         "composer/installers": "~1.0"
     },
     "extra": {
-        "display-name": "Recent Topics (fork by IMC & LukeWCS)",
+        "display-name": "Recent Topics NG",
         "soft-require": {
             "phpbb/phpbb": ">=3.3.5,<3.4.0@dev"
-        },
-        "version-check": {
-            "host": "www.phpbb.com",
-            "directory": "/customise/db/extension/recent_topics_2",
-            "filename": "version_check",
-            "ssl": true
         }
     }
 }

--- a/event/listener.php
+++ b/event/listener.php
@@ -199,13 +199,16 @@ class listener implements EventSubscriberInterface
 	public function add_permission($event)
 	{
 		$permissions = $event['permissions'];
-		$permissions['u_rt_view']				= ['lang' => 'ACL_U_RT_VIEW', 'cat' => 'misc'];
-		$permissions['u_rt_enable']				= ['lang' => 'ACL_U_RT_ENABLE', 'cat' => 'misc'];
-		$permissions['u_rt_location']			= ['lang' => 'ACL_U_RT_LOCATION', 'cat' => 'misc'];
-		$permissions['u_rt_sort_start_time']	= ['lang' => 'ACL_U_RT_SORT_START_TIME', 'cat' => 'misc'];
-		$permissions['u_rt_unread_only']		= ['lang' => 'ACL_U_RT_UNREAD_ONLY', 'cat' => 'misc'];
-		$permissions['u_rt_number']				= ['lang' => 'ACL_U_RT_NUMBER', 'cat' => 'misc'];
+		$categories = $event['categories'];
+		$categories['recenttopics'] = 'ACL_CAT_RTNG';
+		$permissions['u_rt_view']				= ['lang' => 'ACL_U_RTNG_VIEW'				, 'cat' => 'recenttopics'];
+		$permissions['u_rt_enable']				= ['lang' => 'ACL_U_RTNG_ENABLE'			, 'cat' => 'recenttopics'];
+		$permissions['u_rt_location']			= ['lang' => 'ACL_U_RTNG_LOCATION'			, 'cat' => 'recenttopics'];
+		$permissions['u_rt_sort_start_time']	= ['lang' => 'ACL_U_RTNG_SORT_START_TIME'	, 'cat' => 'recenttopics'];
+		$permissions['u_rt_unread_only']		= ['lang' => 'ACL_U_RTNG_UNREAD_ONLY'		, 'cat' => 'recenttopics'];
+		$permissions['u_rt_number']				= ['lang' => 'ACL_U_RTNG_NUMBER'			, 'cat' => 'recenttopics'];
 		$event['permissions'] = $permissions;
+		$event['categories'] = $categories;
 	}
 
 	/**

--- a/language/de/permissions_recenttopics.php
+++ b/language/de/permissions_recenttopics.php
@@ -39,10 +39,11 @@ if (empty($lang) || !is_array($lang))
 // ‚ ‘ ’ « » “ ” … „ “
 //
 $lang = array_merge($lang, [
-	'ACL_U_RT_VIEW'            => 'Aktuelle Themen: Kann „Aktuelle Themen“ sehen.',
-	'ACL_U_RT_ENABLE'          => 'Aktuelle Themen: Kann „Aktuelle Themen“ aktivieren / deaktivieren.',
-	'ACL_U_RT_LOCATION'        => 'Aktuelle Themen: Kann den Anzeigeort des Blocks „Aktuelle Themen“ ändern.',
-	'ACL_U_RT_SORT_START_TIME' => 'Aktuelle Themen: Kann Sortierung des Blocks „Aktuelle Themen“ ändern.',
-	'ACL_U_RT_UNREAD_ONLY'     => 'Aktuelle Themen: Kann „Aktuelle Themen“-Modus auf „nur ungelesene“ ändern.',
-	'ACL_U_RT_NUMBER'          => 'Aktuelle Themen: Kann Anzahl der aktuellen Themen pro Seite ändern.',
+	'ACL_CAT_RTNG' 					=> 'Aktuelle Themen',
+	'ACL_U_RTNG_VIEW'				=> 'Kann „Aktuelle Themen“ sehen.',
+	'ACL_U_RTNG_ENABLE'				=> 'Kann „Aktuelle Themen“ aktivieren / deaktivieren.',
+	'ACL_U_RTNG_LOCATION'			=> 'Kann den Anzeigeort des Blocks „Aktuelle Themen“ ändern.',
+	'ACL_U_RTNG_SORT_START_TIME'	=> 'Kann Sortierung des Blocks „Aktuelle Themen“ ändern.',
+	'ACL_U_RTNG_UNREAD_ONLY'		=> 'Kann „Aktuelle Themen“-Modus auf „nur ungelesene“ ändern.',
+	'ACL_U_RTNG_NUMBER'				=> 'Kann Anzahl der aktuellen Themen pro Seite ändern.',
 ]);

--- a/language/de_x_sie/permissions_recenttopics.php
+++ b/language/de_x_sie/permissions_recenttopics.php
@@ -39,10 +39,11 @@ if (empty($lang) || !is_array($lang))
 // ‚ ‘ ’ « » “ ” … „ “
 //
 $lang = array_merge($lang, [
-	'ACL_U_RT_VIEW'            => 'Aktuelle Themen: Kann „Aktuelle Themen“ sehen.',
-	'ACL_U_RT_ENABLE'          => 'Aktuelle Themen: Kann „Aktuelle Themen“ aktivieren / deaktivieren.',
-	'ACL_U_RT_LOCATION'        => 'Aktuelle Themen: Kann den Anzeigeort des Blocks „Aktuelle Themen“ ändern.',
-	'ACL_U_RT_SORT_START_TIME' => 'Aktuelle Themen: Kann Sortierung des Blocks „Aktuelle Themen“ ändern.',
-	'ACL_U_RT_UNREAD_ONLY'     => 'Aktuelle Themen: Kann „Aktuelle Themen“-Modus auf „nur ungelesene“ ändern.',
-	'ACL_U_RT_NUMBER'          => 'Aktuelle Themen: Kann Anzahl der aktuellen Themen pro Seite ändern.',
+	'ACL_CAT_RTNG' 					=> 'Aktuelle Themen',
+	'ACL_U_RTNG_VIEW'				=> 'Kann „Aktuelle Themen“ sehen.',
+	'ACL_U_RTNG_ENABLE'				=> 'Kann „Aktuelle Themen“ aktivieren / deaktivieren.',
+	'ACL_U_RTNG_LOCATION'			=> 'Kann den Anzeigeort des Blocks „Aktuelle Themen“ ändern.',
+	'ACL_U_RTNG_SORT_START_TIME'	=> 'Kann Sortierung des Blocks „Aktuelle Themen“ ändern.',
+	'ACL_U_RTNG_UNREAD_ONLY'		=> 'Kann „Aktuelle Themen“-Modus auf „nur ungelesene“ ändern.',
+	'ACL_U_RTNG_NUMBER'				=> 'Kann Anzahl der aktuellen Themen pro Seite ändern.',
 ]);

--- a/language/en/permissions_recenttopics.php
+++ b/language/en/permissions_recenttopics.php
@@ -39,10 +39,11 @@ if (empty($lang) || !is_array($lang))
 // ‚ ‘ ’ « » “ ” … „ “
 //
 $lang = array_merge($lang, [
-	'ACL_U_RT_VIEW'            => 'Recent Topics: can view Recent topics.',
-	'ACL_U_RT_ENABLE'          => 'Recent Topics: can enable or disable Displaying Recent Topics.',
-	'ACL_U_RT_LOCATION'        => 'Recent Topics: can select display location of Recent topics blocks.',
-	'ACL_U_RT_SORT_START_TIME' => 'Recent Topics: can change topic sort order.',
-	'ACL_U_RT_UNREAD_ONLY'     => 'Recent Topics: can change setting to only display unread topics.',
-	'ACL_U_RT_NUMBER'          => 'Recent Topics: can change setting of number of recent topics to show per page.',
+	'ACL_CAT_RTNG' 					=> 'Recent Topics',
+	'ACL_U_RTNG_VIEW'				=> 'Can view Recent Topics.',
+	'ACL_U_RTNG_ENABLE'				=> 'Can enable or disable Recent Topics.',
+	'ACL_U_RTNG_LOCATION'			=> 'Can select display location of Recent Topics blocks.',
+	'ACL_U_RTNG_SORT_START_TIME'	=> 'Can change topic sort order.',
+	'ACL_U_RTNG_UNREAD_ONLY'		=> 'Can change setting to only display unread topics.',
+	'ACL_U_RTNG_NUMBER'				=> 'Can change setting of number of recent topics to show per page.',
 ]);


### PR DESCRIPTION
* Permission management:
  * A separate category “Recent Topics” was created for the permissions. The “Misc” category is no longer used.
  * Adjusted language files and removed the "Recent Topics:" prefix.
* The previous temporary project name "Recent Topics (fork by IMC & LukeWCS)" has been changed to the final name "Recent Topics NG".
  * `composer.json` adjusted accordingly.
  * The new prefix for variable names and other identifiers is now `RTNG`. Used for the first time with the new permissions category.
* LukeWCSphpBBConfirmBox 1.4.3:
  * Code optimization.
* Other changes in `composer.json`:
  * Removed version check for phpBB.com because it doesn't make sense with the fork. At a later date we will add a new version check for RTNG.
  * Description reduced to the essentials. Version information does not belong there, as there are dedicated places for it.
* Miscellaneous:
  * Reduced `README.md` to the minimum and added current information.